### PR TITLE
feat: support modifying archipelago options

### DIFF
--- a/etc/archipelago.api.md
+++ b/etc/archipelago.api.md
@@ -25,6 +25,8 @@ export interface ArchipelagoController {
     // (undocumented)
     getPeersData(ids: string[]): Promise<Record<string, PeerData>>;
     // (undocumented)
+    modifyOptions(options: UpdatableArchipelagoParameters): void;
+    // (undocumented)
     setPeersPositions(...requests: PeerPositionChange[]): void;
     // (undocumented)
     subscribeToUpdates(subscriber: UpdateSubscriber): void;
@@ -107,6 +109,9 @@ export type PeerPositionChange = {
 
 // @public (undocumented)
 export type Position3D = [number, number, number];
+
+// @public (undocumented)
+export type UpdatableArchipelagoParameters = Partial<Omit<ArchipelagoOptions, 'islandIdGenerator'>>;
 
 // @public (undocumented)
 export type UpdateSubscriber = (updates: IslandUpdates) => any;

--- a/src/controller/ArchipelagoController.ts
+++ b/src/controller/ArchipelagoController.ts
@@ -7,6 +7,7 @@ import {
   PeerData,
   PeerPositionChange,
   Position3D,
+  UpdatableArchipelagoParameters,
   UpdateSubscriber,
 } from "../types/interfaces"
 
@@ -187,6 +188,10 @@ export class ArchipelagoControllerImpl implements ArchipelagoController {
       this.pendingUpdates.set(id, { type: "clear" })
       this.activePeers.delete(id)
     }
+  }
+
+  modifyOptions(options: UpdatableArchipelagoParameters) {
+    this.workerController.sendMessageToWorker({ type: "apply-options-update", updates: options })
   }
 
   async getPeersCount(): Promise<number> {

--- a/src/controller/ArchipelagoController.ts
+++ b/src/controller/ArchipelagoController.ts
@@ -142,7 +142,7 @@ export class ArchipelagoControllerImpl implements ArchipelagoController {
     loop()
   }
 
-  async flush() {
+  flush() {
     if (this.pendingUpdates.size > 0 && this.workerController.workerStatus === "idle") {
       console.log(`Flushing ${this.pendingUpdates.size} updates`)
       const updatesToFlush = this.pendingUpdates

--- a/src/domain/Archipelago.ts
+++ b/src/domain/Archipelago.ts
@@ -7,6 +7,7 @@ import {
   PeerPositionChange,
   Island,
   ArchipelagoParameters,
+  UpdatableArchipelagoParameters,
 } from "../types/interfaces"
 import { findMax, popFirstByOrder, popMax } from "../misc/utils"
 import { IArchipelago } from "./interfaces"
@@ -70,6 +71,17 @@ export class Archipelago implements IArchipelago {
 
   constructor(options: ArchipelagoParameters) {
     this.options = { ...defaultOptions(), ...options }
+  }
+
+  modifyOptions(options: UpdatableArchipelagoParameters): IslandUpdates {
+    this.options = { ...this.options, ...options }
+
+    let updates: IslandUpdates = {}
+    const allIslands = new Set(this.islands.keys())
+
+    this.updateIslands(updates, allIslands)
+
+    return updates
   }
 
   getOptions() {

--- a/src/domain/interfaces.ts
+++ b/src/domain/interfaces.ts
@@ -1,5 +1,5 @@
 import { Island, IslandUpdates, PeerPositionChange } from ".."
-import { PeerData } from "../types/interfaces"
+import { PeerData, UpdatableArchipelagoParameters } from "../types/interfaces"
 
 export interface IArchipelago {
   getIslandsCount(): number
@@ -9,4 +9,5 @@ export interface IArchipelago {
   getIslands(): Island[]
   getPeerData(id: string): PeerData | undefined
   setPeersPositions(requests: PeerPositionChange[]): IslandUpdates
+  modifyOptions(options: UpdatableArchipelagoParameters): IslandUpdates;
 }

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -34,6 +34,7 @@ export interface ArchipelagoController {
   getPeersData(ids: string[]): Promise<Record<string, PeerData>>
   dispose(): Promise<void>
   flush(): Promise<void>
+  modifyOptions(options: UpdatableArchipelagoParameters): void
 }
 
 export type IslandUpdate = {
@@ -53,6 +54,8 @@ export type ArchipelagoOptions = {
 export type MandatoryArchipelagoOptions = Pick<ArchipelagoOptions, "joinDistance" | "leaveDistance">
 
 export type ArchipelagoParameters = MandatoryArchipelagoOptions & Partial<ArchipelagoOptions>
+
+export type UpdatableArchipelagoParameters = Partial<Omit<ArchipelagoOptions, 'islandIdGenerator'>>
 
 export type Logger = {
   info(message?: any, ...optionalParams: any[]): void

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -33,7 +33,7 @@ export interface ArchipelagoController {
   getPeerData(id: string): Promise<PeerData | undefined>
   getPeersData(ids: string[]): Promise<Record<string, PeerData>>
   dispose(): Promise<void>
-  flush(): Promise<void>
+  flush(): void
   modifyOptions(options: UpdatableArchipelagoParameters): void
 }
 

--- a/src/types/messageTypes.ts
+++ b/src/types/messageTypes.ts
@@ -1,9 +1,14 @@
 import { PeerPositionChange } from ".."
-import { Island, IslandUpdates, PeerData } from "./interfaces"
+import { Island, IslandUpdates, PeerData, UpdatableArchipelagoParameters } from "./interfaces"
 
 export type ApplyUpdates = {
   type: "apply-updates"
   updates: { positionUpdates: PeerPositionChange[]; clearUpdates: string[] }
+}
+
+export type ApplyOptionsUpdate = {
+  type: "apply-options-update"
+  updates: UpdatableArchipelagoParameters
 }
 
 type Request = { requestId: string }
@@ -90,6 +95,7 @@ export type WorkerStatus = "working" | "idle" | "unknown"
 
 export type WorkerMessage =
   | ApplyUpdates
+  | ApplyOptionsUpdate
   | WorkerResponse
   | WorkerRequest
   | IslandsUpdated

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -140,7 +140,6 @@ function applyOptionsUpdate(newOptions: UpdatableArchipelagoParameters) {
   logger.debug(`Processing options update`)
 
   const updates = archipelago.modifyOptions(newOptions)
-  console.log(updates)
   emitUpdates(updates)
 
   logger.debug(`Processing updates took: ${Date.now() - startTime}`)

--- a/test/archipelago-controller.spec.ts
+++ b/test/archipelago-controller.spec.ts
@@ -70,7 +70,7 @@ describe("archipelago controller", () => {
     await expectIslandsInControllerWith(controller, ["1", "2"], ["3"])
   })
 
-  it("should forward positions and receive updates", async () => {
+  it("should forward option updates and receive updates", async () => {
     controller.setPeersPositions(
       { id: "1", position: [0, 0, 0] },
       { id: "2", position: [16, 0, 16] },

--- a/test/archipelago.spec.ts
+++ b/test/archipelago.spec.ts
@@ -120,6 +120,16 @@ describe("archipelago", () => {
     expectIslandsWith(archipelago, ["1"])
   })
 
+  it("recalculates islands when options are modified", () => {
+    setPositions(["1", 0, 0, 0], ["2", 16, 0, 16])
+    expectIslandWith(archipelago, "1", "2")
+
+    archipelago.modifyOptions({ joinDistance: 4, leaveDistance: 5 })
+
+    expectIslandWith(archipelago, "1")
+    expectIslandWith(archipelago, "2")
+  })
+
   function expectChangedTo(updates: IslandUpdates, peerId: string, islandId: string) {
     expect.strictEqual(updates[peerId].islandId, islandId)
     expect.strictEqual(updates[peerId].action, "changeTo")


### PR DESCRIPTION
We are now adding the possibility to modify options (such as leave/enter distance) during runtime. When any of these options is modified, all island assignments will be recalculated.